### PR TITLE
[WIP] ignore private `gtk_widget_path_iter_add_qclass`

### DIFF
--- a/bindings/Gtk/Gtk.overrides
+++ b/bindings/Gtk/Gtk.overrides
@@ -6,3 +6,6 @@ ignore TreeModelFilter.set_modify_func
 
 # Signal with an (out) (caller-allocates) parameter, which we do not support.
 ignore Overlay.get-child-position
+
+# gtk_widget_path_iter_add_qclass isn't exported despite being present in Gtk-3.0.typelib
+ignore WidgetPath.iter_add_qclass


### PR DESCRIPTION
otherwise it makes linking to fail, see https://gitter.im/haskell-gi/haskell-gi?at=56a8e37ddc33b33c754830b8

This is a quick fix, I didn't test it yet.