### PR TITLE
Update PKGS.sh for OS X

### DIFF
--- a/bindings/PKGS.sh
+++ b/bindings/PKGS.sh
@@ -1,14 +1,23 @@
 #!/bin/bash
 basever=$(ghc-pkg list base)
+unamestr=$(uname)
 
 # Packages compatible with base >= 4.7
-base47PKGS="GLib GObject Atk Gio Soup cairo Pango PangoCairo GdkPixbuf Gdk Gtk JavaScriptCore-4.0 WebKit2 WebKit2WebExtension GtkSource GIRepository Poppler JavaScriptCore-3.0 WebKit Vte Notify"
+base47PKGS="GLib GObject Atk Gio Soup cairo Pango PangoCairo GdkPixbuf Gdk Gtk GtkSource GIRepository Poppler JavaScriptCore-3.0 WebKit Vte Notify"
 # Packages compatible with base >= 4.8
 base48PKGS="Gst GstBase GstAudio GstVideo"
 
+if [[ "$unamestr" == 'Darwin' ]]; then
+    # Only present on OS X
+    extraPKGS="GtkosxApplication"
+else
+    # WebKit2 is broken for MacPorts with Quartz enabled right now
+    extraPKGS="JavaScriptCore-4.0 WebKit2 WebKit2WebExtension"
+fi
+
 echo $basever | grep -q "4.7"
 if [ $? == 0 ]; then
-    echo $base47PKGS
+    echo $base47PKGS $extraPKGS
 else
-    echo $base47PKGS $base48PKGS
+    echo $base47PKGS $base48PKGS $extraPKGS
 fi


### PR DESCRIPTION
Includes GtkosxApplication when run on OS X and also disables WebKit2
for now (it currently does not build with MacPorts on Quartz Gtk+).