### PR TITLE
Fix genCallbackWrapper for signal returning Ptr ()

### DIFF
--- a/src/GI/Signal.hs
+++ b/src/GI/Signal.hs
@@ -236,7 +236,8 @@ genCallbackWrapper subsec cb name' dataptrs hInArgs hOutArgs isSignal = do
       case returnType cb of
         Nothing -> return ()
         Just r -> do
-           if returnMayBeNull cb
+           nullableReturnType <- typeIsNullable r
+           if returnMayBeNull cb && nullableReturnType
            then do
              line "maybeM nullPtr result $ \\result' -> do"
              indent $ unwrapped "result'"


### PR DESCRIPTION
Updated genCallbackWrapper so it is consistent with hOutType, that only
applies Maybe to the type if both returnMayBeNull and typeIsNulllable
are True.  (Not sure if this is the right thing to do but GLib 2.48.0
was failing to compile without this change)