### PR TITLE
Ignore missing mingw functions for now (see #14)

### DIFF
--- a/bindings/GLib/GLib.overrides
+++ b/bindings/GLib/GLib.overrides
@@ -30,28 +30,50 @@ ignore base64_decode_step
 ignore base64_encode_step
 ignore base64_encode_close
 
-# Not supported on Windows.
 if windows
-   ignore file_get_contents
-   ignore file_open_tmp
-   ignore file_test
-   ignore filename_from_uri
-   ignore filename_from_utf8
-   ignore filename_to_uri
-   ignore filename_to_utf8
-   ignore get_current_dir
-   ignore getenv
-   ignore setenv
-   ignore unsetenv
-   ignore IOChannel.new_file
+   # Windows only macros in glib/gfileutils.h
+   set-attr GLib/file_get_contents c:identifier g_file_get_contents_utf8
+   set-attr GLib/file_open_tmp c:identifier g_file_open_tmp_utf8
+   set-attr GLib/file_test c:identifier g_file_test_utf8
+   set-attr GLib/mkstemp c:identifier g_mkstemp_utf8
+   set-attr GLib/get_current_dir c:identifier g_get_current_dir_utf8
+
+   # Windows only macros in glib/gconvert.h
+   set-attr GLib/filename_from_uri c:identifier g_filename_from_uri_utf8
+   set-attr GLib/filename_from_utf8 c:identifier g_filename_from_utf8_utf8
+   set-attr GLib/filename_to_uri c:identifier g_filename_to_uri_utf8
+   set-attr GLib/filename_to_utf8 c:identifier g_filename_to_utf8_utf8
+
+   # Windows only macros in glib/genviron.h
+   set-attr GLib/getenv c:identifier g_getenv_utf8
+   set-attr GLib/setenv c:identifier g_setenv_utf8
+   set-attr GLib/unsetenv c:identifier g_unsetenv_utf8
+   
+   # Windows only macros in glib/gdir.h
+   set-attr GLib/Dir/open c:identifier g_dir_open_utf8
+   set-attr GLib/Dir/read_name c:identifier g_dir_read_name_utf8
+
+   # Windows only macros in glib/gmodule.h (not in GIR yet)
+   set-attr GLib/Module/open c:identifier g_module_name_utf8
+   set-attr GLib/Module/name c:identifier g_module_name_utf8
+
+   # Windows only macros in glib/giochannel.h
+   set-attr GLib/IOChannel/new_file c:identifier g_io_channel_new_file_utf8
+
+   # ifdef G_OS_UNIX in glib/gmain.h
+   ignore Source.add_unix_fd
    ignore Source.modify_unix_fd
    ignore Source.query_unix_fd
    ignore Source.remove_unix_fd
-   ignore spawn_async
-   ignore spawn_async_with_pipes
-   ignore spawn_command_line_async
-   ignore spawn_command_line_sync
-   ignore spawn_sync
+
+   # Windows only macros in glib/spawn.h
+   set-attr GLib/spawn_async c:identifier g_spawn_async_utf8
+   set-attr GLib/spawn_async_with_pipes c:identifier g_spawn_async_with_pipes_utf8
+   set-attr GLib/spawn_command_line_async c:identifier g_spawn_command_line_async_utf8
+   set-attr GLib/spawn_command_line_sync c:identifier g_spawn_command_line_sync_utf8
+   set-attr GLib/spawn_sync c:identifier g_spawn_sync_utf8
+
+   # In G_OS_UNIX only file glib/glib-unix.h
    ignore unix_error_quark
    ignore unix_fd_add
    ignore unix_fd_add_full
@@ -61,5 +83,4 @@ if windows
    ignore unix_signal_add
    ignore unix_signal_add_full
    ignore unix_signal_source_new
-   ignore mkstemp
 endif

--- a/bindings/GdkPixbuf/GdkPixbuf.overrides
+++ b/bindings/GdkPixbuf/GdkPixbuf.overrides
@@ -2,8 +2,10 @@ namespace GdkPixbuf
 
 # Not supported on Windows.
 if windows
-   ignore Pixbuf.new_from_file
-   ignore Pixbuf.new_from_file_at_scale
-   ignore Pixbuf.new_from_file_at_size
-   ignore Pixbuf.savev
+   set-attr GdkPixbuf/Pixbuf/new_from_file c:identifier gdk_pixbuf_new_from_file_utf8
+   set-attr GdkPixbuf/Pixbuf/new_from_file_at_scale c:identifier gdk_pixbuf_new_from_file_at_scale_utf8
+   set-attr GdkPixbuf/Pixbuf/new_from_file_at_size c:identifier gdk_pixbuf_new_from_file_at_size_utf8
+   set-attr GdkPixbuf/Pixbuf/save c:identifier gdk_pixbuf_save_utf8
+   set-attr GdkPixbuf/Pixbuf/savev c:identifier gdk_pixbuf_savev_utf8
+   set-attr GdkPixbuf/PixbufAnimation/new_from_file c:identifier gdk_pixbuf_animation_new_from_file_utf8
 endif

--- a/bindings/Gio/Gio.overrides
+++ b/bindings/Gio/Gio.overrides
@@ -15,4 +15,31 @@ if windows
    ignore DBusMessage.get_unix_fd_list
    ignore DBusMessage.set_unix_fd_list
    ignore DBusMethodInvocation.return_value_with_unix_fd_list
+   ignore unix_mounts_changed_since
+   ignore unix_mount_points_changed_since
+   ignore unix_mount_is_system_internal
+   ignore unix_mount_is_readonly
+   ignore unix_mount_guess_symbolic_icon
+   ignore unix_mount_guess_should_display
+   ignore unix_mount_guess_name
+   ignore unix_mount_guess_icon
+   ignore unix_mount_guess_can_eject
+   ignore unix_mount_get_mount_path
+   ignore unix_mount_get_fs_type
+   ignore unix_mount_get_device_path
+   ignore unix_mount_free
+   ignore unix_mount_compare
+   ignore unix_is_mount_path_system_internal
+   ignore unix_is_mount_path_system_internal
+   ignore DBusConnection.call_with_unix_fd_list_finish
+   ignore DBusConnection.call_with_unix_fd_list_sync
+   ignore DBusConnection.call_with_unix_fd_list
+   ignore UnixFDList.get_type
+   ignore UnixFDList.append
+   ignore UnixFDList.get
+   ignore UnixFDList.get_length
+   ignore UnixFDList.peek_fds
+   ignore UnixFDList.steal_fds
+   ignore UnixFDList.new
+   ignore UnixFDList.new_from_array
 endif


### PR DESCRIPTION
Can we do this as until we work out a better solution for #14 ?  I worked around the two functions missing in OS X quartz by adding them to [quartzfix.c](https://github.com/haskell-gi/gi-gtk-hs/blob/master/cbits/quartzfix.c), but the same trick does not work for mingw for some reason.