### PR TITLE
Ignore _utf8 functions in gir on Windows

### DIFF
--- a/bindings/GLib/GLib.overrides
+++ b/bindings/GLib/GLib.overrides
@@ -37,28 +37,45 @@ if windows
    set-attr GLib/file_test c:identifier g_file_test_utf8
    set-attr GLib/mkstemp c:identifier g_mkstemp_utf8
    set-attr GLib/get_current_dir c:identifier g_get_current_dir_utf8
+   ignore file_get_contents_utf8
+   ignore file_open_tmp_utf8
+   ignore file_test_utf8
+   ignore mkstemp_utf8
+   ignore get_current_dir_utf8
 
    # Windows only macros in glib/gconvert.h
    set-attr GLib/filename_from_uri c:identifier g_filename_from_uri_utf8
    set-attr GLib/filename_from_utf8 c:identifier g_filename_from_utf8_utf8
    set-attr GLib/filename_to_uri c:identifier g_filename_to_uri_utf8
    set-attr GLib/filename_to_utf8 c:identifier g_filename_to_utf8_utf8
+   ignore filename_from_uri_utf8
+   ignore filename_from_utf8_utf8
+   ignore filename_to_uri_utf8
+   ignore filename_to_utf8_utf8
 
    # Windows only macros in glib/genviron.h
    set-attr GLib/getenv c:identifier g_getenv_utf8
    set-attr GLib/setenv c:identifier g_setenv_utf8
    set-attr GLib/unsetenv c:identifier g_unsetenv_utf8
-   
+   ignore getenv_utf8
+   ignore setenv_utf8
+   ignore unsetenv_utf8
+
    # Windows only macros in glib/gdir.h
    set-attr GLib/Dir/open c:identifier g_dir_open_utf8
    set-attr GLib/Dir/read_name c:identifier g_dir_read_name_utf8
+   ignore Dir.open_utf8
+   ignore Dir.read_name_utf8
 
    # Windows only macros in glib/gmodule.h (not in GIR yet)
    set-attr GLib/Module/open c:identifier g_module_name_utf8
    set-attr GLib/Module/name c:identifier g_module_name_utf8
+   ignore Module.open_utf8
+   ignore Module.name_utf8
 
    # Windows only macros in glib/giochannel.h
    set-attr GLib/IOChannel/new_file c:identifier g_io_channel_new_file_utf8
+   ignore IOChannel.new_file_utf8
 
    # ifdef G_OS_UNIX in glib/gmain.h
    ignore Source.add_unix_fd
@@ -72,6 +89,11 @@ if windows
    set-attr GLib/spawn_command_line_async c:identifier g_spawn_command_line_async_utf8
    set-attr GLib/spawn_command_line_sync c:identifier g_spawn_command_line_sync_utf8
    set-attr GLib/spawn_sync c:identifier g_spawn_sync_utf8
+   ignore spawn_async_utf8
+   ignore spawn_async_with_pipes_utf8
+   ignore spawn_command_line_async_utf8
+   ignore spawn_command_line_sync_utf8
+   ignore spawn_sync_utf8
 
    # In G_OS_UNIX only file glib/glib-unix.h
    ignore unix_error_quark


### PR DESCRIPTION
Some functions are in the gir file twice on windows.