### PR TITLE
Fixes for building on windows with MSYS2

### DIFF
--- a/bindings/GLib/GLib.overrides
+++ b/bindings/GLib/GLib.overrides
@@ -30,6 +30,85 @@ ignore base64_decode_step
 ignore base64_encode_step
 ignore base64_encode_close
 
+if windows
+   # Windows only macros in glib/gfileutils.h
+   set-attr GLib/file_get_contents c:identifier g_file_get_contents_utf8
+   set-attr GLib/file_open_tmp c:identifier g_file_open_tmp_utf8
+   set-attr GLib/file_test c:identifier g_file_test_utf8
+   set-attr GLib/mkstemp c:identifier g_mkstemp_utf8
+   set-attr GLib/get_current_dir c:identifier g_get_current_dir_utf8
+   ignore file_get_contents_utf8
+   ignore file_open_tmp_utf8
+   ignore file_test_utf8
+   ignore mkstemp_utf8
+   ignore get_current_dir_utf8
+
+   # Windows only macros in glib/gconvert.h
+   set-attr GLib/filename_from_uri c:identifier g_filename_from_uri_utf8
+   set-attr GLib/filename_from_utf8 c:identifier g_filename_from_utf8_utf8
+   set-attr GLib/filename_to_uri c:identifier g_filename_to_uri_utf8
+   set-attr GLib/filename_to_utf8 c:identifier g_filename_to_utf8_utf8
+   ignore filename_from_uri_utf8
+   ignore filename_from_utf8_utf8
+   ignore filename_to_uri_utf8
+   ignore filename_to_utf8_utf8
+
+   # Windows only macros in glib/genviron.h
+   set-attr GLib/getenv c:identifier g_getenv_utf8
+   set-attr GLib/setenv c:identifier g_setenv_utf8
+   set-attr GLib/unsetenv c:identifier g_unsetenv_utf8
+   ignore getenv_utf8
+   ignore setenv_utf8
+   ignore unsetenv_utf8
+
+   # Windows only macros in glib/gdir.h
+   set-attr GLib/Dir/open c:identifier g_dir_open_utf8
+   set-attr GLib/Dir/read_name c:identifier g_dir_read_name_utf8
+   ignore Dir.open_utf8
+   ignore Dir.read_name_utf8
+
+   # Windows only macros in glib/gmodule.h (not in GIR yet)
+   set-attr GLib/Module/open c:identifier g_module_name_utf8
+   set-attr GLib/Module/name c:identifier g_module_name_utf8
+   ignore Module.open_utf8
+   ignore Module.name_utf8
+
+   # Windows only macros in glib/giochannel.h
+   set-attr GLib/IOChannel/new_file c:identifier g_io_channel_new_file_utf8
+   ignore IOChannel.new_file_utf8
+   # Use win32_new_socket (this "stream" version was only for binary compatibility)
+   ignore IOChannel.win32_new_stream_socket
+
+   # ifdef G_OS_UNIX in glib/gmain.h
+   ignore Source.add_unix_fd
+   ignore Source.modify_unix_fd
+   ignore Source.query_unix_fd
+   ignore Source.remove_unix_fd
+
+   # Windows only macros in glib/spawn.h
+   set-attr GLib/spawn_async c:identifier g_spawn_async_utf8
+   set-attr GLib/spawn_async_with_pipes c:identifier g_spawn_async_with_pipes_utf8
+   set-attr GLib/spawn_command_line_async c:identifier g_spawn_command_line_async_utf8
+   set-attr GLib/spawn_command_line_sync c:identifier g_spawn_command_line_sync_utf8
+   set-attr GLib/spawn_sync c:identifier g_spawn_sync_utf8
+   ignore spawn_async_utf8
+   ignore spawn_async_with_pipes_utf8
+   ignore spawn_command_line_async_utf8
+   ignore spawn_command_line_sync_utf8
+   ignore spawn_sync_utf8
+
+   # In G_OS_UNIX only file glib/glib-unix.h
+   ignore unix_error_quark
+   ignore unix_fd_add
+   ignore unix_fd_add_full
+   ignore unix_fd_source_new
+   ignore unix_open_pipe
+   ignore unix_set_fd_nonblocking
+   ignore unix_signal_add
+   ignore unix_signal_add_full
+   ignore unix_signal_source_new
+endif
+
 # Generated from glib 2.48.0 with xsltproc Nullable.xslt GLib-2.0.gir
 set-attr GLib/Array/sort_with_data/@parameters/user_data nullable 1
 set-attr GLib/AsyncQueue/pop/@return-value nullable 1

--- a/bindings/Gio/Gio.overrides
+++ b/bindings/Gio/Gio.overrides
@@ -42,6 +42,9 @@ if windows
    ignore UnixFDList.steal_fds
    ignore UnixFDList.new
    ignore UnixFDList.new_from_array
+   ignore DBusProxy.call_with_unix_fd_list_finish
+   ignore DBusProxy.call_with_unix_fd_list_sync
+   ignore DBusProxy.call_with_unix_fd_list   
 endif
 
 # Generated from gio 2.48.0 with xsltproc Nullable.xslt Gio-2.0.gir


### PR DESCRIPTION
Ignores some functions that are not present and adds back a bunch of
windows GLib.overrides that went missing by mistake.