### PR TITLE
Use Name instead of pair of Text for Interface and Alias

### DIFF
--- a/lib/Data/GI/CodeGen/Callable.hs
+++ b/lib/Data/GI/CodeGen/Callable.hs
@@ -312,9 +312,8 @@ prepareInCallback arg (Callback cb) = do
 
   (maker, wrapper, drop) <-
       case argType arg of
-        TInterface ns n ->
+        TInterface tn@(Name _ n) ->
             do
-              let tn = Name ns n
               drop <- if callableHasClosures cb
                       then Just <$> qualifiedSymbol (callbackDropClosures n) tn
                       else return Nothing

--- a/lib/Data/GI/CodeGen/Code.hs
+++ b/lib/Data/GI/CodeGen/Code.hs
@@ -436,7 +436,7 @@ missingInfoError s = throwError $ CGErrorMissingInfo s
 
 findAPI :: Type -> CodeGen (Maybe API)
 findAPI TError = Just <$> findAPIByName (Name "GLib" "Error")
-findAPI (TInterface ns n) = Just <$> findAPIByName (Name ns n)
+findAPI (TInterface n) = Just <$> findAPIByName n
 findAPI _ = return Nothing
 
 -- | Find the API associated with a given type. If the API cannot be

--- a/lib/Data/GI/CodeGen/CodeGen.hs
+++ b/lib/Data/GI/CodeGen/CodeGen.hs
@@ -330,7 +330,7 @@ fixConstructorReturnType :: Bool -> Name -> Callable -> Callable
 fixConstructorReturnType returnsGObject cn c = c { returnType = returnType' }
     where
       returnType' = if returnsGObject then
-                        Just (TInterface (namespace cn) (name cn))
+                        Just (TInterface cn)
                     else
                         returnType c
 
@@ -403,7 +403,7 @@ genGObjectCasts isIU n cn_ parents = do
 genObject :: Name -> Object -> CodeGen ()
 genObject n o = do
   let name' = upperName n
-  let t = (\(Name ns' n') -> TInterface ns' n') n
+  let t = TInterface n
   isGO <- isGObject t
 
   if not isGO

--- a/lib/Data/GI/CodeGen/Constant.hs
+++ b/lib/Data/GI/CodeGen/Constant.hs
@@ -61,7 +61,7 @@ assignValue name t@(TBasicType b) value = do
   ht <- tshow <$> haskellType t
   hv <- showBasicType b value
   writePattern name (SimpleSynonym hv ht)
-assignValue name t@(TInterface _ _) value = do
+assignValue name t@(TInterface _) value = do
   ht <- tshow <$> haskellType t
   api <- findAPI t
   case api of

--- a/lib/Data/GI/CodeGen/GObject.hs
+++ b/lib/Data/GI/CodeGen/GObject.hs
@@ -16,9 +16,8 @@ import Data.GI.CodeGen.Type
 
 -- Returns whether the given type is a descendant of the given parent.
 typeDoParentSearch :: Name -> Type -> CodeGen Bool
-typeDoParentSearch parent (TInterface ns n) = findAPIByName name >>=
-                                              apiDoParentSearch parent name
-                                                  where name = Name ns n
+typeDoParentSearch parent (TInterface n) = findAPIByName n >>=
+                                           apiDoParentSearch parent n
 typeDoParentSearch _ _ = return False
 
 apiDoParentSearch :: Name -> Name -> API -> CodeGen Bool
@@ -27,7 +26,7 @@ apiDoParentSearch parent n api
     | otherwise   = case api of
       APIObject o ->
         case objParent o of
-          Just (Name pns pn) -> typeDoParentSearch parent (TInterface pns pn)
+          Just  p -> typeDoParentSearch parent (TInterface p)
           Nothing -> return False
       APIInterface iface ->
         do let prs = ifPrerequisites iface

--- a/lib/Data/GI/CodeGen/Properties.hs
+++ b/lib/Data/GI/CodeGen/Properties.hs
@@ -59,8 +59,8 @@ propTypeStr t = case t of
    TCArray True _ _ (TBasicType TUTF8) -> return "StringArray"
    TCArray True _ _ (TBasicType TFileName) -> return "StringArray"
    TGList (TBasicType TPtr) -> return "PtrGList"
-   t@(TInterface ns n) -> do
-     api <- findAPIByName (Name ns n)
+   t@(TInterface n) -> do
+     api <- findAPIByName n
      case api of
        APIEnum _ -> return "Enum"
        APIFlags _ -> return "Flags"

--- a/lib/Data/GI/CodeGen/Struct.hs
+++ b/lib/Data/GI/CodeGen/Struct.hs
@@ -49,7 +49,7 @@ fixCallbackStructFields (Name ns structName) s = s {structFields = fixedFields}
               case fieldCallback field of
                 Nothing -> field
                 Just _ -> let n' = fieldCallbackType structName field
-                          in field {fieldType = TInterface ns n'}
+                          in field {fieldType = TInterface (Name ns n')}
 
 -- | Fix the interface names of callback fields in an APIStruct to
 -- correspond to the ones that we are going to generate. If something
@@ -280,7 +280,7 @@ buildFieldAttributes n field
      else return Nothing
 
     where privateType :: Type -> Bool
-          privateType (TInterface _ n) = "Private" `T.isSuffixOf` n
+          privateType (TInterface n) = "Private" `T.isSuffixOf` name n
           privateType _ = False
 
 genStructOrUnionFields :: Name -> [Field] -> CodeGen ()

--- a/lib/Data/GI/CodeGen/SymbolNaming.hs
+++ b/lib/Data/GI/CodeGen/SymbolNaming.hs
@@ -43,7 +43,7 @@ classConstraint n@(Name _ s) = qualifiedSymbol ("Is" <> s) n
 -- | Same as `classConstraint`, but applicable directly to a type. The
 -- type should be a `TInterface`, otherwise an error will be raised.
 typeConstraint :: Type -> CodeGen Text
-typeConstraint (TInterface ns s) = classConstraint (Name ns s)
+typeConstraint (TInterface n) = classConstraint n
 typeConstraint t = error $ "Class constraint for non-interface type: " <> show t
 
 -- | Foreign type associated with a callback type. It can be passed in
@@ -107,14 +107,14 @@ upperName (Name _ s) = underscoresToCamelCase (sanitize s)
 -- | Return an identifier for the given interface type valid in the current
 -- module.
 qualifiedAPI :: Name -> CodeGen Text
-qualifiedAPI n@(Name ns s) = do
-  api <- getAPI (TInterface ns s)
+qualifiedAPI n@(Name ns _) = do
+  api <- getAPI (TInterface n)
   qualified ("GI" : ucFirst ns : submoduleLocation n api) n
 
 -- | Construct an identifier for the given symbol in the given API.
 qualifiedSymbol :: Text -> Name -> CodeGen Text
-qualifiedSymbol s n@(Name ns nn) = do
-  api <- getAPI (TInterface ns nn)
+qualifiedSymbol s n@(Name ns _) = do
+  api <- getAPI (TInterface n)
   qualified ("GI" : ucFirst ns : submoduleLocation n api) (Name ns s)
 
 -- | Construct the submodule name (as a list, to be joined by

--- a/lib/Data/GI/CodeGen/Transfer.hs
+++ b/lib/Data/GI/CodeGen/Transfer.hs
@@ -29,7 +29,7 @@ basicFreeFn :: Type -> Maybe Text
 basicFreeFn (TBasicType TUTF8) = Just "freeMem"
 basicFreeFn (TBasicType TFileName) = Just "freeMem"
 basicFreeFn (TBasicType _) = Nothing
-basicFreeFn (TInterface _ _) = Nothing
+basicFreeFn (TInterface _) = Nothing
 basicFreeFn (TCArray False (-1) (-1) _) = Nothing -- Just passing it along
 basicFreeFn (TCArray{}) = Just "freeMem"
 basicFreeFn (TGArray _) = Just "unrefGArray"
@@ -58,7 +58,7 @@ basicFreeFnOnError TParamSpec transfer =
     return $ if transfer == TransferEverything
              then Just "unrefGParamSpec"
              else Nothing
-basicFreeFnOnError t@(TInterface _ _) transfer = do
+basicFreeFnOnError t@(TInterface _) transfer = do
   api <- findAPI t
   case api of
     Just (APIObject _) -> if transfer == TransferEverything

--- a/lib/Data/GI/GIR/Alias.hs
+++ b/lib/Data/GI/GIR/Alias.hs
@@ -20,7 +20,7 @@ namespaceListAliases ns =
       Just nsName -> case runParser nsName M.empty ns parseAliases of
                        Left err -> (error . T.unpack) err
                        Right aliases -> M.fromList (map addNS aliases)
-                           where addNS (n, t) = (Alias (nsName, n), t)
+                           where addNS (n, t) = (Alias (Name nsName n), t)
 
 -- | Parse all the aliases in the current namespace
 parseAliases :: Parser [(Text, Type)]

--- a/lib/Data/GI/GIR/BasicTypes.hs
+++ b/lib/Data/GI/GIR/BasicTypes.hs
@@ -20,7 +20,7 @@ data Transfer = TransferNothing
                 deriving (Show, Eq, Ord)
 
 -- | An alias, which is simply (Namespace, name).
-newtype Alias = Alias (Text, Text) deriving (Ord, Eq, Show)
+newtype Alias = Alias Name deriving (Ord, Eq, Show)
 
 -- | Basic types. These are generally trivial to marshal, and the GIR
 -- assumes that they are defined.
@@ -63,5 +63,5 @@ data Type
     | TGList Type      -- ^ GList
     | TGSList Type     -- ^ GSList
     | TGHash Type Type -- ^ GHashTable
-    | TInterface Text Text -- ^ A reference to some API in the GIR
+    | TInterface Name  -- ^ A reference to some API in the GIR
       deriving (Eq, Show, Ord)

--- a/lib/Data/GI/GIR/Field.hs
+++ b/lib/Data/GI/GIR/Field.hs
@@ -54,7 +54,7 @@ parseField = do
                  t <- parseType
                  ct <- parseCType
                  return (t, Just ct)
-               Just (Name ns n) -> return (TInterface ns n, Nothing)
+               Just n -> return (TInterface n, Nothing)
         return (t, ct, callback)
       else do
         callbacks <- parseAllChildrenWithLocalName "callback" parseName
@@ -63,7 +63,7 @@ parseField = do
                t <- parseType
                ct <- parseCType
                return (t, Just ct, Nothing)
-          [Name ns n] -> return (TInterface ns n, Nothing, Nothing)
+          [n] -> return (TInterface n, Nothing, Nothing)
           _ -> parseError "Multiple callbacks in field"
   return $ Field {
                fieldName = name

--- a/lib/Data/GI/GIR/Parser.hs
+++ b/lib/Data/GI/GIR/Parser.hs
@@ -101,15 +101,15 @@ currentNamespace = ctxNamespace <$> ask
 
 -- | Check whether there is an alias for the given name, and return
 -- the corresponding type in case it exists, and otherwise a TInterface.
-resolveQualifiedTypeName :: Text -> Text -> Parser Type
-resolveQualifiedTypeName ns n = do
+resolveQualifiedTypeName :: Name -> Parser Type
+resolveQualifiedTypeName name = do
   ctx <- ask
-  case M.lookup (Alias (ns, n)) (knownAliases ctx) of
+  case M.lookup (Alias name) (knownAliases ctx) of
     -- The resolved type may be an alias itself, like for
     -- Gtk.Allocation -> Gdk.Rectangle -> cairo.RectangleInt
-    Just (TInterface ns n) -> resolveQualifiedTypeName ns n
+    Just (TInterface n) -> resolveQualifiedTypeName n
     Just t -> return t
-    Nothing -> return $ TInterface ns n
+    Nothing -> return $ TInterface name
 
 -- | Return the value of an attribute for the given element. If the
 -- attribute is not present this throws an error.

--- a/lib/Data/GI/GIR/Type.hs
+++ b/lib/Data/GI/GIR/Type.hs
@@ -114,7 +114,7 @@ parseFundamentalType "GLib" "Error" = return TError
 parseFundamentalType "GLib" "Variant" = return TVariant
 parseFundamentalType "GObject" "ParamSpec" = return TParamSpec
 -- A TInterface type (basically, everything that is not of a known type).
-parseFundamentalType ns n = resolveQualifiedTypeName ns n
+parseFundamentalType ns n = resolveQualifiedTypeName (Name ns n)
 
 -- | Parse information on a "type" element. Returns either a `Type`,
 -- or `Nothing` indicating that the name of the type in the


### PR DESCRIPTION
I wasn't able to run the test suite locally, so definitely should undergo some more testing than I've done. Also breaks API, of course.