### PR TITLE
Don't expose GstByte{Reader,Writer} in bindings

### DIFF
--- a/bindings/GstBase/GstBase.overrides
+++ b/bindings/GstBase/GstBase.overrides
@@ -1,5 +1,10 @@
 namespace GstBase
 
+# Bunch of inline functions in a header, almost certainly more efficient to
+# handle natively in Haskell
+ignore ByteReader
+ignore ByteWriter
+
 # Generated from gstreamer-base 1.8.0 with xsltproc Nullable.xslt GstBase-1.0.gir
 set-attr GstBase/Adapter/get_buffer/@return-value nullable 1
 set-attr GstBase/Adapter/get_buffer_fast/@return-value nullable 1


### PR DESCRIPTION
They render gi-gstbase unusable since a lot of the functions are written
as static inlines in the headers, meaning the symbols don't exist in
libgstbase-1.0.so.

This should not have a real impact, as we expect that this sort of
functionality is better handled by some other library native to Haskell.