### PR TITLE
Updates Gtk.overrides Button set_image image parameter to allow null

### DIFF
--- a/bindings/Gtk/Gtk.overrides
+++ b/bindings/Gtk/Gtk.overrides
@@ -163,6 +163,7 @@ set-attr Gtk/BuilderConnectFunc/@parameters/connect_object nullable 1
 set-attr Gtk/BuilderConnectFunc/@parameters/user_data nullable 1
 set-attr Gtk/Button/new_from_icon_name/@parameters/icon_name nullable 1
 set-attr Gtk/Button/get_image/@return-value nullable 1
+set-attr Gtk/Button/set_image/@parameters/image nullable 1
 set-attr Gtk/Calendar/set_detail_func/@parameters/data nullable 1
 set-attr Gtk/CalendarDetailFunc/@return-value nullable 1
 set-attr Gtk/CalendarDetailFunc/@parameters/user_data nullable 1


### PR DESCRIPTION
Hello.

When upgrading from GTK+ 3.22.16 to 3.22.24, the `/usr/share/gir-1.0/Gtk-3.0.gir` file changed to indicate that `buttonSetImage` allows the image to be null. 

```diff
-          <parameter name="image" transfer-ownership="none">                       
-            <doc xml:space="preserve">a widget to set as the image for the button</doc>                                                                                 
+          <parameter name="image"                                                                                                                                       
+                     transfer-ownership="none"                                     
+                     nullable="1"                                                                                                                                       
+                     allow-none="1">                                               
+            <doc xml:space="preserve">a widget to set as the image for the button, or %NULL to unset</doc> 
```

I am not sure when this changed but the 3.22.16 version (and maybe others) of the GIR was wrong.

Looking at the GTK documentation, the image can be null. This function is compatible with version 2.6 and later.

https://developer.gnome.org/gtk3/stable/GtkButton.html#gtk-button-set-image

This will update the binding to match.

https://hackage.haskell.org/package/gi-gtk-3.0.17/docs/GI-Gtk-Objects-Button.html#v:buttonSetImage

:+1: 

