### PR TITLE
Adds an example of how to emit a signal to a GTK widget

### DIFF
--- a/examples/GtkEmitSignal.hs
+++ b/examples/GtkEmitSignal.hs
@@ -1,0 +1,102 @@
+{-# LANGUAGE OverloadedStrings, OverloadedLabels #-}
+
+{-
+  A minimal example of how to emit a signal to a GTK widget.
+
+  The 3-Clause BSD License
+
+  Copyright 2017 David Lettier
+
+  Redistribution and use in source and binary forms,
+  with or without modification, are permitted provided
+  that the following conditions are met:
+
+  1. Redistributions of source code must retain the above
+  copyright notice, this list of conditions and the following disclaimer.
+
+  2. Redistributions in binary form must reproduce the above
+  copyright notice, this list of conditions and the following
+  disclaimer in the documentation and/or other materials provided
+  with the distribution.
+
+  3. Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived
+  from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+  OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-}
+
+import Foreign.Ptr
+import Data.GI.Base.GValue
+import Data.GI.Base.ManagedPtr
+import Data.GI.Base.Utils
+import Data.GI.Base
+import GI.GObject.Functions
+import qualified GI.Gtk
+
+main :: IO ()
+main = do
+  -- Initialize GTK
+  _ <- GI.Gtk.init Nothing
+
+  -- Create a new window with the title `GTK Emit Signal Example`
+  win <- new GI.Gtk.Window [ #title := "GTK Emit Signal Example" ]
+
+  -- When we destroy (close) the window, quit the GTK main loop
+  _ <- on win #destroy GI.Gtk.mainQuit
+
+  -- Create a new text entry widget
+  -- After we emit our signal, the text inside the box will say `Haskell`
+  entry <- new GI.Gtk.Entry [ #text := "askell" ]
+
+  -- Add the text entry to our window
+  #add win entry
+
+  -- When the text entry is ready
+  _ <- on entry #realize $ do
+
+    -- Get the GType for the GtkEntry
+    gtype <- gobjectType entry
+
+    -- Get the signal ID and Quark detail
+    -- based on the `insert-at-cursor` signal name
+    -- and the GType GtkEntry
+    (_, signalId, detail) <- signalParseName "insert-at-cursor" gtype False
+
+    -- Get access to our GtkEntry* entryPtr (pointer to GtkEntry)
+    withManagedPtr entry $ \ entryPtr -> do
+
+      -- Create a managed GValue* with the type GObject
+      object <- buildGValue gtype set_object entryPtr
+
+      -- Create a managed GValue* with the type gchar* (string)
+      -- The `H` is the character we will insert at the beginning
+      -- of the text entry to complete the word Haskell
+      string <- buildGValue gtypeString set_string (Just "H")
+
+      -- Emit the signal to object making sure to place
+      -- it first in the parameter array
+      -- The rest of the array holds the parameters that the
+      -- signal accepts
+      -- In this case `insert-at-cursor` accepts a string
+      -- parameter
+      _ <- signalEmitv [object, string] signalId detail
+
+      return ()
+
+  -- Show the window containing our text entry
+  #showAll win
+
+  -- Run the GTK main loop
+  GI.Gtk.main

--- a/examples/haskell-gi-examples.cabal
+++ b/examples/haskell-gi-examples.cabal
@@ -75,3 +75,13 @@ executable GstGtkX11
                       , haskell-gi-base == 0.20.*
   other-extensions:     OverloadedStrings
   ghc-options:          -O -threaded -with-rtsopts=-N -Wall
+
+executable gtk-emit-signal
+  main-is:            GtkEmitSignal.hs
+  build-depends:        base >= 4.7 && < 4.10
+                      , haskell-gi-base
+                      , gi-gobject
+                      , gi-glib
+                      , gi-gtk
+  default-language:   Haskell2010
+  ghc-options:        -Wall -threaded


### PR DESCRIPTION
Hello @garetxe,

The documentation for `signalEmitv`/`g_signal_emitv` is somewhat sparse--both on the C and Haskell side.

This should help out anyone wishing to emit signals to GObjects. 

![screenshot_2017-12-27_04-16-18](https://user-images.githubusercontent.com/1661343/34376964-c0c1aace-eabc-11e7-91cb-d0fa34fd6dfc.png)

https://github.com/gtk2hs/gtk2hs/issues/44

[Hackage](https://hackage.haskell.org/package/gi-gobject/docs/GI-GObject-Functions.html#v:signalEmitv)
[GNOME Developer](https://developer.gnome.org/gobject/stable/gobject-Signals.html#g-signal-emitv)

:+1: 