### PR TITLE
Add some instances for AttrOpTag

### DIFF
--- a/base/Data/GI/Base/Attributes.hs
+++ b/base/Data/GI/Base/Attributes.hs
@@ -242,6 +242,7 @@ type family AttrOpAllowed (tag :: AttrOpTag) (info :: *) (useType :: *) :: Const
 
 -- | Possible operations on an attribute.
 data AttrOpTag = AttrGet | AttrSet | AttrConstruct | AttrClear
+  deriving (Eq, Ord, Enum, Bounded, Show)
 
 #if MIN_VERSION_base(4,9,0)
 -- | A user friendly description of the `AttrOpTag`, useful when


### PR DESCRIPTION
These are admittedly not very useful for the lifted types, but I'd like to use them for run-time values to enumerate attribute information, as well. They shouldn't cause any harm, but I could also use a different equivalent type if you'd prefer to keep these clean.