### PR TITLE
Add gtk+-3.0 to dbusmenu's pkgconfig-depends

### DIFF
--- a/bindings/DbusmenuGtk3/pkg.info
+++ b/bindings/DbusmenuGtk3/pkg.info
@@ -16,5 +16,5 @@
         "gi-gdk == 3.0.*",
         "gi-gdkpixbuf == 2.0.*"
     ],
-    "pkgconfigDepends": "dbusmenu-gtk3-0.4"
+    "pkgconfigDepends": "dbusmenu-gtk3-0.4, gtk+-3.0"
 }


### PR DESCRIPTION
At the moment Taffybar can't build via Nix because https://github.com/NixOS/nixpkgs/issues/40164

This commit adds gtk+-3.0 to pkgconfig-depends so that cabal2nix will reference it.