### PR TITLE
Add an exception to the LGPL for the generated libraries to allow static linking

### DIFF
--- a/bindings/genBuildInfo.hs
+++ b/bindings/genBuildInfo.hs
@@ -101,8 +101,8 @@ writeSetup fname info =
     where tshow :: Show a => a -> Text
           tshow = T.pack . show
 
-writeLicense :: FilePath -> IO ()
-writeLicense fname = B.writeFile fname (TE.encodeUtf8 PI.licenseText)
+writeLicense :: FilePath -> ProjectInfo -> IO ()
+writeLicense fname info = B.writeFile fname (TE.encodeUtf8 $ PI.licenseText (name info))
 
 writeStackYaml :: FilePath -> IO ()
 writeStackYaml fname =
@@ -138,6 +138,6 @@ main = do
          info <- readGIRInfo (dir </> "pkg.info")
          writeCabal (dir </> T.unpack (name info) <.> "cabal") info
          writeSetup (dir </> "Setup.hs") info
-         writeLicense (dir </> "LICENSE")
+         writeLicense (dir </> "LICENSE") info
          writeStackYaml (dir </> "stack.yaml")
          writeReadme (dir </> "README.md") info

--- a/cmdline/haskell-gi.hs
+++ b/cmdline/haskell-gi.hs
@@ -221,7 +221,7 @@ processMod options ovs extraPaths name = do
     putStrLn "\t\t+ Setup.hs"
     utf8WriteFile (p "Setup.hs") setupHs
     putStrLn "\t\t+ LICENSE"
-    utf8WriteFile (p "LICENSE") licenseText
+    utf8WriteFile (p "LICENSE") (licenseText name)
 
 dump :: Options -> Overrides -> Text -> IO ()
 dump options ovs name = do

--- a/lib/Data/GI/CodeGen/ProjectInfo.hs
+++ b/lib/Data/GI/CodeGen/ProjectInfo.hs
@@ -14,6 +14,7 @@ module Data.GI.CodeGen.ProjectInfo
     , standardDeps
     ) where
 
+import Data.Monoid ((<>))
 import Data.Text (Text)
 import qualified Data.Text as T (unlines)
 
@@ -66,8 +67,25 @@ standardDeps = ["bytestring >= 0.10 && < 1",
 category :: Text
 category = "Bindings"
 
-licenseText :: Text
-licenseText = T.unlines
+staticLinkingException :: Text -> Text
+staticLinkingException name = T.unlines
+ ["The " <> name <> " library and included works are provided under the terms of the"
+ ,"GNU Library General Public License (LGPL) version 2.1 with the following"
+ ,"exception:"
+ ,""
+ ,"Static linking of applications or any other source to the " <> name <> " library"
+ ,"does not constitute a modified or derivative work and does not require"
+ ,"the author(s) to provide source code for said work, to link against the"
+ ,"shared " <> name <> " libraries, or to link their applications against a"
+ ,"user-supplied version of " <> name <> ". If you link applications to a modified"
+ ,"version of " <> name <> ", then the changes to " <> name <> " must be provided under the"
+ ,"terms of the LGPL."
+ ,""
+ ,"----------------------------------------------------------------------------"
+ ,""]
+
+licenseText :: Text -> Text
+licenseText name = staticLinkingException name <> T.unlines
  ["                  GNU LESSER GENERAL PUBLIC LICENSE"
  ,"                       Version 2.1, February 1999"
  ,""


### PR DESCRIPTION
Normally, under the terms of the LGPL, when an application is linked against an LGPL library, the end user must be able to modify and replace the LGPL part of the application. This is difficult for statically linked Haskell libraries in GHC, so application authors that use LGPL code may be obliged to supply source code for their applications.

This pull request adds an exception to the licenses of the generated bindings to explicitly allow static linking.  This exception is based on https://github.com/gtkd-developers/GtkD/blob/master/COPYING.

If this exception is acceptable to the project maintainers, then I would also like to extend it to the haskell-gi-base and haskell-gi libraries since all of the generated bindings are dependent on those libraries.