### PR TITLE
Add missing nullable annotations in Dbusmenu

### DIFF
--- a/bindings/Dbusmenu/Dbusmenu.overrides
+++ b/bindings/Dbusmenu/Dbusmenu.overrides
@@ -1,1 +1,6 @@
 set-attr Dbusmenu/MenuitemClass/buildvariant/@type name zzz
+set-attr Dbusmenu/Menuitem/child_find/@return-value nullable 1
+set-attr Dbusmenu/Menuitem/find_id/@return-value nullable 1
+set-attr Dbusmenu/Menuitem/property_get/@return-value nullable 1
+set-attr Dbusmenu/Menuitem/property_get_byte_array/@return-value nullable 1
+set-attr Dbusmenu/Menuitem/property_get_variant/@return-value nullable 1


### PR DESCRIPTION
See #174 for background. I found 6 functions that seemed to need the annotation. I added it to 5 of them and it changed the type signatures appropriately; I haven't got menuitemPropertyList to work. Adding the override doesn't seem to change its type signature.

I'm not sure if it's because of something I'm doing wrong or because in this case NULL doesn't actual require us to change anything; [the docstring of the function](https://hackage.haskell.org/package/gi-dbusmenu-0.4.1/docs/GI-Dbusmenu-Objects-Menuitem.html#g:21) says it returns "A list of strings or NULL if there are none". I would think if you're returning a list then you wouldn't need to do anything special if there were none since you'd just return an empty list, so I wonder if it just says that because in C the `GList*` type signals emptiness by being NULL, given that C uses null-terminated strings. I ended up leaving that one out of this commit.

I haven't looked into DbusmenuGtk3 yet. I think it also needs some of these but I figured I should get someone to take a look at this before I go further.

@IvanMalison , you were the one who reported this originally so I hope to get your confirmation that this fixes the problem.