### PR TITLE
Add missing annotations for Vte functions

### DIFF
--- a/bindings/Vte/Vte.overrides
+++ b/bindings/Vte/Vte.overrides
@@ -14,3 +14,9 @@ set-attr Vte/Terminal/get_current_directory_uri/@return-value nullable 1
 # The return value is nullable, but it is not properly annotated as such
 # https://github.com/haskell-gi/haskell-gi/issues/185
 set-attr Vte/Terminal/get_window_title/@return-value nullable 1
+
+# The return value is nullable, but it is not properly annotated as such
+set-attr Vte/Terminal/match_check_event/@return-value nullable 1
+
+# The return value is nullable, but it is not properly annotated as such
+set-attr Vte/Terminal/hyperlink_check_event/@return-value nullable 1


### PR DESCRIPTION
This PR add a two missing annotations for Vte functions. I found these working on cdepillabout/termonad#12

I also reported it upstream:
https://gitlab.gnome.org/GNOME/vte/issues/190