### PR TITLE
gi-gtk-hs: relax constraint on base-compat

### DIFF
--- a/gi-gtk-hs/gi-gtk-hs.cabal
+++ b/gi-gtk-hs/gi-gtk-hs.cabal
@@ -1,5 +1,5 @@
 name:                gi-gtk-hs
-version:             0.3.8.0
+version:             0.3.8.1
 synopsis:            A wrapper for gi-gtk, adding a few more idiomatic API parts on top
 description:         A wrapper for gi-gtk, adding a few more idiomatic API parts on top
 homepage:            https://github.com/haskell-gi/gi-gtk-hs
@@ -29,7 +29,7 @@ library
                        Data.GI.Gtk.ComboBox
 
   build-depends:       base >= 4.9 && <5,
-                       base-compat >=0.9.0 && <0.11,
+                       base-compat >=0.9.0 && <0.12,
                        mtl >= 2.1 && <2.3,
                        transformers >=0.3.0.0 && <0.6,
                        containers >=0.5.5.1 && <0.7,


### PR DESCRIPTION
As already discussed in haskell-gi/gi-gtk-hs#27

Could you please make a new release on hackage after this is merged?