### PR TITLE
Split "build from source" step in two

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -49,7 +49,8 @@ jobs:
       if: steps.gtksheet-cache.outputs.cache-hit != 'true'
       with:
         repository: fpaquet/gtksheet
-        ref: V{{ env.gtksheet_version}}
+        ref: V${{ env.gtksheet_version}}
+        path: gtksheet
 
     - name: Build GtkSheet from source
       if: steps.gtksheet-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -74,6 +74,7 @@ jobs:
         popd
 
     - name: Generate bindings
+      run: |
         pushd bindings
         cabal new-update
         cabal new-run genBuildInfo $(bash PKGS.sh)

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -45,12 +45,14 @@ jobs:
         path: gtksheet
         key: ${{ env.gtksheet_version }}
 
-    - name: Build GtkSheet from source
-      uses: actions/checkout@v2
+    - uses: actions/checkout@v2
       if: steps.gtksheet-cache.outputs.cache-hit != 'true'
       with:
         repository: fpaquet/gtksheet
         ref: V{{ env.gtksheet_version}}
+
+    - name: Build GtkSheet from source
+      if: steps.gtksheet-cache.outputs.cache-hit != 'true'
       run: |
         pushd gtksheet
         # Configure and install


### PR DESCRIPTION
Apparently a step cannot have both uses and run, so this splits the GtkSheet build from source step into a uses step and a run step.