### PR TITLE
Add missing (<>) imports

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ['8.4', '8.6', '8.8', '8.10']
+        ghc: ['8.0', '8.4', '8.6', '8.8', '8.10']
 
     steps:
     - uses: actions/checkout@v1

--- a/haskell-gi.cabal
+++ b/haskell-gi.cabal
@@ -1,5 +1,5 @@
 name:                haskell-gi
-version:             0.24.7
+version:             0.24.8
 synopsis:            Generate Haskell bindings for GObject Introspection capable libraries
 description:         Generate Haskell bindings for GObject Introspection capable libraries. This includes most notably
                      Gtk+, but many other libraries in the GObject ecosystem provide introspection data too.

--- a/lib/Data/GI/CodeGen/Conversions.hsc
+++ b/lib/Data/GI/CodeGen/Conversions.hsc
@@ -39,6 +39,10 @@ module Data.GI.CodeGen.Conversions
 
 #include <glib-object.h>
 
+#if !MIN_VERSION_base(4,13,0)
+import Data.Monoid ((<>))
+#endif
+
 import Control.Monad (when)
 import Data.Maybe (isJust)
 import Data.Text (Text)

--- a/lib/Data/GI/CodeGen/LibGIRepository.hs
+++ b/lib/Data/GI/CodeGen/LibGIRepository.hs
@@ -15,6 +15,9 @@ module Data.GI.CodeGen.LibGIRepository
 #if !MIN_VERSION_base(4,8,0)
 import Control.Applicative ((<$>))
 #endif
+#if !MIN_VERSION_base(4,13,0)
+import Data.Monoid ((<>))
+#endif
 
 import Control.Monad (forM, (>=>))
 import qualified Data.Map as M

--- a/lib/Data/GI/GIR/Object.hs
+++ b/lib/Data/GI/GIR/Object.hs
@@ -4,6 +4,10 @@ module Data.GI.GIR.Object
     , parseObject
     ) where
 
+#if !MIN_VERSION_base(4,13,0)
+import Data.Monoid ((<>))
+#endif
+
 import Data.Text (Text)
 
 import Data.GI.GIR.Method (Method, parseMethod, MethodType(..))


### PR DESCRIPTION
See https://github.com/haskell-gi/haskell-gi/issues/330.
Add (conditional) Monoid-imports to the affected modules.

Addditionally, adds ghc 8.0 to CI test matrix.