### PR TITLE
Added a signal name phantom to SignalProxy.

### DIFF
--- a/base/Data/GI/Base/Attributes.hs
+++ b/base/Data/GI/Base/Attributes.hs
@@ -151,7 +151,7 @@ import Control.Monad.IO.Class (MonadIO, liftIO)
 
 import Data.GI.Base.BasicTypes (GObject)
 import Data.GI.Base.GValue (GValueConstruct)
-import Data.GI.Base.Overloading (HasAttributeList, ResolveAttribute)
+import Data.GI.Base.Overloading (HasAttributeList, ResolveAttribute, ResolveSignal)
 
 import {-# SOURCE #-} Data.GI.Base.Signals (SignalInfo(..), SignalProxy, on)
 
@@ -439,7 +439,7 @@ data AttrOp obj (tag :: AttrOpTag) where
               AttrSetTypeConstraint info (AttrTransferType info)) =>
              AttrLabelProxy (attr :: Symbol) -> b -> AttrOp obj tag
     -- | Connect the given signal to a signal handler.
-    On    :: (GObject obj, SignalInfo info) =>
+    On    :: (GObject obj, SignalInfo info, info ~ ResolveSignal slot obj) =>
              SignalProxy obj slot info -> HaskellCallbackType info -> AttrOp obj tag
 
 -- | Set a number of properties for some object.

--- a/base/Data/GI/Base/Attributes.hs
+++ b/base/Data/GI/Base/Attributes.hs
@@ -440,7 +440,7 @@ data AttrOp obj (tag :: AttrOpTag) where
              AttrLabelProxy (attr :: Symbol) -> b -> AttrOp obj tag
     -- | Connect the given signal to a signal handler.
     On    :: (GObject obj, SignalInfo info) =>
-             SignalProxy obj info -> HaskellCallbackType info -> AttrOp obj tag
+             SignalProxy obj slot info -> HaskellCallbackType info -> AttrOp obj tag
 
 -- | Set a number of properties for some object.
 set :: forall o m. MonadIO m => o -> [AttrOp o 'AttrSet] -> m ()

--- a/base/Data/GI/Base/Signals.hs
+++ b/base/Data/GI/Base/Signals.hs
@@ -125,7 +125,7 @@ data SignalConnectMode = SignalConnectBefore  -- ^ Run before the default handle
 
 -- | Connect a signal to a signal handler.
 on :: forall object slot info m.
-      (GObject object, MonadIO m, SignalInfo info) =>
+      (GObject object, MonadIO m, SignalInfo info, info ~ ResolveSignal slot object) =>
       object -> SignalProxy object slot info
              -> HaskellCallbackType info -> m SignalHandlerId
 on o p c =

--- a/base/Data/GI/Base/Signals.hs-boot
+++ b/base/Data/GI/Base/Signals.hs-boot
@@ -12,6 +12,7 @@ import Data.GI.Base.BasicTypes (GObject)
 import Control.Monad.IO.Class (MonadIO)
 import Foreign.C (CULong)
 import Data.Text (Text)
+import Data.GI.Base.Overloading (ResolveSignal)
 
 data SignalConnectMode = SignalConnectBefore
         | SignalConnectAfter
@@ -31,6 +32,6 @@ data SignalProxy object (slot::Symbol) info where
 type SignalHandlerId = CULong
 
 on :: forall object slot info m.
-      (GObject object, MonadIO m, SignalInfo info) =>
+      (GObject object, MonadIO m, SignalInfo info, info ~ ResolveSignal slot object) =>
        object -> SignalProxy object slot info
              -> HaskellCallbackType info -> m SignalHandlerId

--- a/base/Data/GI/Base/Signals.hs-boot
+++ b/base/Data/GI/Base/Signals.hs-boot
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE AllowAmbiguousTypes #-}
@@ -6,6 +7,7 @@
 
 module Data.GI.Base.Signals (SignalInfo(..), SignalProxy, on) where
 
+import GHC.TypeLits (Symbol)
 import Data.GI.Base.BasicTypes (GObject)
 import Control.Monad.IO.Class (MonadIO)
 import Foreign.C (CULong)
@@ -23,12 +25,12 @@ class SignalInfo info where
                      Maybe Text ->
                      IO SignalHandlerId
 
-type role SignalProxy nominal nominal
-data SignalProxy object info where
+type role SignalProxy nominal phantom nominal
+data SignalProxy object (slot::Symbol) info where
 
 type SignalHandlerId = CULong
 
-on :: forall object info m.
+on :: forall object slot info m.
       (GObject object, MonadIO m, SignalInfo info) =>
-       object -> SignalProxy object info
+       object -> SignalProxy object slot info
              -> HaskellCallbackType info -> m SignalHandlerId

--- a/lib/Data/GI/CodeGen/OverloadedSignals.hs
+++ b/lib/Data/GI/CodeGen/OverloadedSignals.hs
@@ -57,7 +57,7 @@ genOverloadedSignalConnectors allAPIs = do
   forM_ signalNames $ \sn -> group $ do
     let camelName = hyphensToCamelCase sn
     line $ "pattern " <> camelName <>
-             " :: SignalProxy object (ResolveSignal \""
+             " :: SignalProxy object \"" <> lcFirst camelName <> "\" (ResolveSignal \""
              <> lcFirst camelName <> "\" object)"
     line $ "pattern " <> camelName <> " = SignalProxy"
     exportDecl $ "pattern " <> camelName


### PR DESCRIPTION
OverloadedLabels is more costly than it should be, and I think I understand why.  Consider the work GHC has to do when it encounters a typical call to this function:

```haskell
-- | Connect a signal to a signal handler.
on :: forall object info m.
      (GObject object, MonadIO m, SignalInfo info) =>
      object -> SignalProxy object info
             -> HaskellCallbackType info -> m SignalHandlerId
```

The SignalProxy was not passed directly.  Rather, a label was used and GHC must identify which instance of the IsLabel class to invoke.  GHC doesn't use constraints to search for instances, it matches against the instance head (SignalProxy object info) and then checks the constraints.  Therefore, to resolve the IsLabel instance, it first wants to resolve the types _object_ and _info_.  The _object_ type is likely easy, but the _info_ type has to be matched against instances of _HaskellCallbackType info_ of which there will likely be many.

I propose that a phantom parameter be added to SignalProxy so that it can match against the known signal name at instance-head-matching time rather than postponing the check to the constraint test.