### PR TITLE
gsk depends on gdkpixbuf

### DIFF
--- a/bindings/Gsk/pkg.info
+++ b/bindings/Gsk/pkg.info
@@ -14,6 +14,7 @@
         "gi-pango == 1.0.*",
         "gi-cairo == 1.0.*",
         "gi-gdk == 4.0.*",
+        "gi-gdkpixbuf == 2.0.*",
         "gi-graphene == 1.0.*",
         "gi-gobject == 2.0.*",
         "gi-glib == 2.0.*"


### PR DESCRIPTION
When I try to build gi-gsk, I get this error:

```
GI/Gsk/Objects/Texture.hs:133:1: error:
    Could not load module ‘GI.GdkPixbuf.Objects.Pixbuf’
    It is a member of the hidden package ‘gi-gdkpixbuf-2.0.24’.
    Perhaps you need to add ‘gi-gdkpixbuf’ to the build-depends in your .cabal file.
    Use -v to see a list of the files searched for.
    |
133 | import qualified GI.GdkPixbuf.Objects.Pixbuf as GdkPixbuf.Pixbuf
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

Adding `gi-gdkpixbuf` to the cabal file I get from `cabal unpack gi-gsk` manually seems to fix things up. I *think* this patch makes the analogous change to `bindings/Gsk`, however, I haven't been able to check it myself. The README appears to not actually have instructions for creating the bindings? A `cabal v2-build all` in the root directory doesn't seem to be the way, at least (it complains about a bunch of missing `.cabal` files); I also unsuccessfully tried running `runhaskell extractDescriptions.hs Gsk` in the `bindings` directory. So I can't test that I've made the right change, please review it carefully.