### PR TITLE
Fix #342: use augmented typelib search path

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ Hopefully this helps to get started! For any further questions there is a gitter
 
 It should be rather easy to generate bindings to any library with `gobject-introspection` support, see the examples in the [bindings](https://github.com/haskell-gi/haskell-gi/tree/master/bindings) folder. Pull requests appreciated!
 
+When adding new bindings, it may be necessary to augment the search paths used for `.gir` and `.typelib`. This can be done by setting the environment variables `HASKELL_GI_GIR_SEARCH_PATH` and `HASKELL_GI_TYPELIB_SEARCHPATH` resepctively.
+
 ## Higher-Level Bindings
 
 The bindings in `haskell-gi` aim for complete coverage of the bound APIs, but as a result they are imperative in flavour. For nicer, higher-level approaches based on these bindings, see:

--- a/lib/Data/GI/CodeGen/API.hs
+++ b/lib/Data/GI/CodeGen/API.hs
@@ -109,7 +109,8 @@ import Data.GI.Base.BasicTypes (GType(..), CGType, gtypeName)
 import Data.GI.Base.Utils (allocMem, freeMem)
 import Data.GI.CodeGen.LibGIRepository (girRequire, Typelib, FieldInfo(..),
                                         girStructFieldInfo, girUnionFieldInfo,
-                                        girLoadGType, girIsSymbolResolvable)
+                                        girLoadGType, girIsSymbolResolvable,
+                                        setupTypelibSearchPath)
 import Data.GI.CodeGen.GType (gtypeIsBoxed)
 import Data.GI.CodeGen.Type (Type)
 import Data.GI.CodeGen.Util (printWarning, terror, tshow)
@@ -518,6 +519,7 @@ loadGIRInfo verbose name version extraPaths rules =  do
     Right (docGIR, depsGIR) -> do
       if girNSName docGIR == name
       then do
+        setupTypelibSearchPath extraPaths
         typelibMap <- M.fromList <$> (forM (docGIR : depsGIR) $ \info -> do
              typelib <- girRequire (girNSName info) (girNSVersion info)
              return (girNSName info, typelib))


### PR DESCRIPTION
Applies the environment variable HASKELL_GI_TYPELIB_SEARCH_PATH when executing genBuildInfo.