### PR TITLE
Work around #350 with gobject `closure` overrides

### DIFF
--- a/bindings/GObject/GObject.overrides
+++ b/bindings/GObject/GObject.overrides
@@ -22,6 +22,13 @@ set-attr GObject/ObjectClass haskell-gi-force-visible 1
 # There is a typo in the introspection data
 set-attr GObject/ParamSpec glib:unref-func g_param_spec_unref
 
+# Work around problem with newer versions where the closure attribute
+# points to the closure arg.
+set-attr GObject/signal_handlers_unblock_matched/@parameters/data closure -1
+set-attr GObject/signal_handlers_block_matched/@parameters/data closure -1
+set-attr GObject/signal_handlers_disconnect_matched/@parameters/data closure -1
+set-attr GObject/signal_handler_find/@parameters/data closure -1
+
 # Generated from gobject 2.48.0 with xsltproc Nullable.xslt GObject-2.0.gir
 set-attr GObject/BindingTransformFunc/@parameters/user_data nullable 1
 set-attr GObject/CClosure/marshal_BOOLEAN__BOXED_BOXED/@parameters/invocation_hint nullable 1


### PR DESCRIPTION
@garetxe, this seems to fix #350 for me.  I'm not sure if this is an error in the GIR for gobject or an error in the way it is interpreted.  Is there an appropriate scope for a pointer that is being used to find signal handlers?