### PR TITLE
Fix of compilation error when haddock is on

### DIFF
--- a/bindings/genBuildInfo.hs
+++ b/bindings/genBuildInfo.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 
--- | Generate the cabal info for the given subdirectories, assuming
+-- Generate the cabal info for the given subdirectories, assuming
 -- the existence of appropriate "pkg.info" files.
 
 import System.Environment (getArgs,getExecutablePath)


### PR DESCRIPTION
Very simple fix for error during haddock build. If you think something else would be better, please suggest and I'll fix it.

Environment:
GHC 8.10.7
cabal 3.6.2.0

~/.cabal/config 
```Cabal
documentation: True
```