### PR TITLE
fix haskell-gi build on ghcHEAD

### DIFF
--- a/lib/Data/GI/CodeGen/Code.hs
+++ b/lib/Data/GI/CodeGen/Code.hs
@@ -71,6 +71,7 @@ module Data.GI.CodeGen.Code
 import Control.Applicative ((<$>))
 import Data.Monoid (Monoid(..))
 #endif
+import Control.Monad (forM, unless, when)
 import Control.Monad.Reader
 import Control.Monad.State.Strict
 import Control.Monad.Except

--- a/lib/Data/GI/CodeGen/Overrides.hs
+++ b/lib/Data/GI/CodeGen/Overrides.hs
@@ -11,6 +11,7 @@ import Control.Applicative ((<$>))
 import Data.Traversable (traverse)
 #endif
 
+import Control.Monad (foldM)
 import Control.Monad.Except
 import Control.Monad.State
 import Control.Monad.Writer (WriterT, execWriterT, tell)


### PR DESCRIPTION
Haskell-gi needs only minor fixes to be successfully built on GHC HEAD (tested with GHC 9.7.20230213). 