### PR TITLE
add a binding to cairo_surface_set_device_scale

### DIFF
--- a/cairo/gi-cairo-render/GI/Cairo/Render/Internal/Surfaces/Surface.chs
+++ b/cairo/gi-cairo-render/GI/Cairo/Render/Internal/Surfaces/Surface.chs
@@ -34,5 +34,6 @@ import qualified Foreign.Storable as C2HSImp
 {#fun surface_mark_dirty           as surfaceMarkDirty          { withSurface* `Surface' } -> `()'#}
 {#fun surface_mark_dirty_rectangle as surfaceMarkDirtyRectangle { withSurface* `Surface', `Int', `Int', `Int', `Int' } -> `()'#}
 {#fun surface_reference            as surfaceReference          { withSurface* `Surface' } -> `()'#}
+{#fun surface_set_device_scale     as surfaceSetDeviceScale     { withSurface* `Surface', `Double', `Double' } -> `()'#}
 {#fun surface_set_device_offset    as surfaceSetDeviceOffset    { withSurface* `Surface', `Double', `Double' } -> `()'#}
 {#fun surface_status               as surfaceStatus             { withSurface* `Surface' } -> `Status' cToEnum#}


### PR DESCRIPTION
This function is essential to make HiDPI rendering non-blurry. Tested with a GTK app on a recent macos machine. 