### PR TITLE
Add a conversion from [Char] to Ptr CInt

### DIFF
--- a/lib/Data/GI/CodeGen/Conversions.hsc
+++ b/lib/Data/GI/CodeGen/Conversions.hsc
@@ -306,6 +306,8 @@ hToF' t a hType fType transfer
         return $ M "(packMapStorableArray realToFrac)"
     | TCArray False _ _ (TBasicType TDouble) <- t =
         return $ M "(packMapStorableArray realToFrac)"
+    | TCArray False _ _ (TBasicType TUniChar) <- t =
+        return $ M "(packMapStorableArray ((fromIntegral . ord)))"
     | TCArray False _ _ (TBasicType _) <- t =
         return $ M "packStorableArray"
     | TCArray False _ _ TGValue <- t =


### PR DESCRIPTION
Fixes #400

As discussed in [#400](https://github.com/haskell-gi/haskell-gi/issues/400#issuecomment-1474660163), glib 2.76.0 fixed the GIR of this function:
```c
void g_unicode_canonical_ordering (gunichar *string, gsize len)
```
The previous wrong GIR caused the generated foreign binding and Haskell code to be:

```haskell
foreign import ccall "g_unicode_canonical_ordering" g_unicode_canonical_ordering ::
    CInt ->                                 -- string : TBasicType TUniChar
    Word64 ->                               -- len : TBasicType TUInt64
    IO ()

unicodeCanonicalOrdering ::
    (B.CallStack.HasCallStack, MonadIO m) =>
    Char
    -- ^ /@string@/: a UCS-4 encoded string.
    -> Word64
    -- ^ /@len@/: the maximum length of /@string@/ to use.
    -> m ()
unicodeCanonicalOrdering string len = liftIO $ do
    let string' = (fromIntegral . ord) string
    g_unicode_canonical_ordering string' len
    return ()
```

which didn't match the actual C function. After the fix, the new generated code now becomes:

```haskell
foreign import ccall "g_unicode_canonical_ordering" g_unicode_canonical_ordering ::
    Ptr CInt ->                             -- string : TCArray False (-1) 1 (TBasicType TUniChar)
    Word64 ->                               -- len : TBasicType TUInt64
    IO ()

-- | Computes the canonical ordering of a string in-place.
-- This rearranges decomposed characters in the string
-- according to their combining classes.  See the Unicode
-- manual for more information.
unicodeCanonicalOrdering ::
    (B.CallStack.HasCallStack, MonadIO m) =>
    [Char]
    -- ^ /@string@/: a UCS-4 encoded string.
    -> m ()
unicodeCanonicalOrdering string = liftIO $ do
    let len = fromIntegral $ P.length string
    string' <- packStorableArray string
    g_unicode_canonical_ordering string' len
    freeMem string'
    return ()
```

This looks reasonable but doesn't compile - `packStorableArray` converters `[Char]` to `Ptr Char`, but we actually need a `Ptr CInt` here, as `TUniChar` maps to `CInt` in terms of foreign type, whereas it maps to `Char` in terms of Haskell type. Thus, we need a specialized case for `TCArray False _ _ (TBasicType TUniChar)` when generating the code that packs Haskell types to foreign types. I'm not sure if this is the correct way to fix the issue, and I have no idea how to test it. While the old binding is clearly wrong, I guess almost nobody uses this function...