### PR TITLE
Remove unneeded overrides from GLib.overrides

### DIFF
--- a/bindings/GLib/GLib.overrides
+++ b/bindings/GLib/GLib.overrides
@@ -6,24 +6,8 @@ ignore IOChannel.read_line_string
 # The test_data argument is not marked as a closure.
 ignore test_add_data_func_full
 
-# "items_read" and "items_written" are out parameters, but they are
-# marked as in parameters the introspection data.
-ignore utf16_to_ucs4
-ignore utf16_to_utf8
-ignore utf8_to_ucs4
-ignore utf8_to_ucs4_fast
-ignore utf8_to_utf16
-
 # "result" parameter is an array, but it is not marked as such.
 ignore unichar_fully_decompose
-
-# The first argument is marked as g_unichar, but it is really an array
-# of g_unichar.
-ignore ucs4_to_utf16
-ignore ucs4_to_utf8
-
-# "line_number" is not marked as out.
-ignore MarkupParseContext.get_position
 
 # These require more complex logic.
 ignore base64_decode_step


### PR DESCRIPTION
As of GLib 2.76.0, these problems are no longer present (parameters corrected marked as out or array, respectively). Tested to build fine with #401 applied.