### PR TITLE
Returned GestureZoom from gestureZoomNew should be wrapped with newObject

### DIFF
--- a/bindings/Gtk-3.0/Gtk.overrides
+++ b/bindings/Gtk-3.0/Gtk.overrides
@@ -35,6 +35,9 @@ set-attr Gtk/RadioMenuItem/set_group/@parameters/group transfer-ownership contai
 set-attr Gtk/RadioToolButton/new/@parameters/group transfer-ownership container
 set-attr Gtk/RadioMenuItem/new_from_stock/@parameters/group transfer-ownership container
 
+#
+set-attr Gtk/GestureZoom/new/@return-value transfer-ownership none
+
 # It is useful to expose these class structs when deriving new types
 set-attr Gtk/WidgetClass haskell-gi-force-visible 1
 set-attr Gtk/ContainerClass haskell-gi-force-visible 1

--- a/examples/advanced/GtkGesture.hs
+++ b/examples/advanced/GtkGesture.hs
@@ -1,0 +1,50 @@
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Main where
+
+import Data.GI.Base (AttrOp ((:=)), new, on)
+import Data.GI.Gtk.Threading (postGUIASync)
+import Data.IORef (newIORef, readIORef, writeIORef)
+import GI.Cairo.Render qualified as R
+import GI.Cairo.Render.Connector qualified as RC
+import GI.Gdk qualified as Gdk
+import GI.Gtk qualified as Gtk
+
+render :: (Double, Double) -> Double -> R.Render ()
+render (xcenter, ycenter) scale = do
+    R.save
+    R.translate xcenter ycenter
+    R.scale scale scale
+    R.setSourceRGBA 0 0 0 1
+    R.rectangle (-100) (-100) 200 200
+    R.fill
+    R.restore
+
+main :: IO ()
+main = do
+    _ <- Gtk.init Nothing
+    ref <- newIORef ((0, 0), 1.0)
+    mainWindow <- new Gtk.Window [#type := Gtk.WindowTypeToplevel]
+    _ <- mainWindow `on` #destroy $ Gtk.mainQuit
+    drawArea <- new Gtk.DrawingArea []
+    _ <- drawArea
+        `on` #draw
+        $ RC.renderWithContext
+        $ do
+            ((xcenter, ycenter), scale) <- R.liftIO $ readIORef ref
+            render (xcenter, ycenter) scale
+            pure True
+    #addEvents drawArea [Gdk.EventMaskButtonPressMask, Gdk.EventMaskTouchpadGestureMask]
+
+    #setDefaultSize mainWindow 640 400
+    gzoom <- Gtk.gestureZoomNew drawArea
+    _ <- Gtk.onGestureZoomScaleChanged gzoom $ \scale -> do
+        (_, xcenter, ycenter) <- #getBoundingBoxCenter gzoom
+        writeIORef ref ((xcenter, ycenter), scale)
+        postGUIASync $
+            #queueDraw drawArea
+    #setPropagationPhase gzoom Gtk.PropagationPhaseBubble
+    #add mainWindow drawArea
+    #showAll mainWindow
+    Gtk.main


### PR DESCRIPTION
I think this is a bug in gtk3 GIR spec file.
With the change in Gtk.overrides setting transfer-ownership to none, the generated code changes `(wrapObject GestureZoom) result` to `(newObject GestureZoom) result`, and an example worked as intended. 

I also added a relevant example `GtkGesture` that dynamically changes a rectangle with scale and center position designated by touchpad pinch-to-zoom gesture.
