### PR TITLE
Add CBool GParamSpec

### DIFF
--- a/base/Data/GI/Base/BasicConversions.hsc
+++ b/base/Data/GI/Base/BasicConversions.hsc
@@ -81,7 +81,7 @@ import qualified Data.Text.Foreign as TF
 import Foreign.Ptr (Ptr, plusPtr, nullPtr, nullFunPtr, castPtr)
 import Foreign.ForeignPtr (withForeignPtr)
 import Foreign.Storable (Storable, peek, poke, sizeOf)
-import Foreign.C.Types (CInt(..), CUInt(..), CSize(..), CChar(..), CBool(..))
+import Foreign.C.Types (CInt(..), CUInt(..), CSize(..), CChar(..))
 import Foreign.C.String (CString, withCString, peekCString)
 import Data.Word
 import Data.Int (Int32)

--- a/base/Data/GI/Base/BasicConversions.hsc
+++ b/base/Data/GI/Base/BasicConversions.hsc
@@ -81,7 +81,7 @@ import qualified Data.Text.Foreign as TF
 import Foreign.Ptr (Ptr, plusPtr, nullPtr, nullFunPtr, castPtr)
 import Foreign.ForeignPtr (withForeignPtr)
 import Foreign.Storable (Storable, peek, poke, sizeOf)
-import Foreign.C.Types (CInt(..), CUInt(..), CSize(..), CChar(..))
+import Foreign.C.Types (CInt(..), CUInt(..), CSize(..), CChar(..), CBool(..))
 import Foreign.C.String (CString, withCString, peekCString)
 import Data.Word
 import Data.Int (Int32)

--- a/base/Data/GI/Base/GObject.hsc
+++ b/base/Data/GI/Base/GObject.hsc
@@ -35,6 +35,7 @@ module Data.GI.Base.GObject
     , gobjectInstallProperty
     , gobjectInstallCIntProperty
     , gobjectInstallCStringProperty
+    , gobjectInstallCBoolProperty
     ) where
 
 import Data.Maybe (catMaybes)
@@ -69,7 +70,8 @@ import Data.GI.Base.CallStack (HasCallStack, prettyCallStack)
 import Data.GI.Base.GParamSpec (PropertyInfo(..),
                                 gParamSpecValue,
                                 CIntPropertyInfo(..), CStringPropertyInfo(..),
-                                gParamSpecCInt, gParamSpecCString,
+                                CBoolPropertyInfo(..),
+                                gParamSpecCInt, gParamSpecCString, gParamSpecCBool,
                                 getGParamSpecGetterSetter,
                                 PropGetSetter(..))
 import Data.GI.Base.GQuark (GQuark(..), gQuarkFromString)
@@ -409,5 +411,13 @@ gobjectInstallCStringProperty :: DerivedGObject o =>
                               GObjectClass -> CStringPropertyInfo o -> IO ()
 gobjectInstallCStringProperty klass propInfo = do
   pspec <- gParamSpecCString propInfo
+  withManagedPtr pspec $ \pspecPtr ->
+    g_object_class_install_property klass 1 pspecPtr
+
+-- | Add a `Foreign.C.CBool`-valued property to the given object class.
+gobjectInstallCBoolProperty :: DerivedGObject o =>
+                            GObjectClass -> CBoolPropertyInfo o -> IO ()
+gobjectInstallCBoolProperty klass propInfo = do
+  pspec <- gParamSpecCBool propInfo
   withManagedPtr pspec $ \pspecPtr ->
     g_object_class_install_property klass 1 pspecPtr

--- a/base/Data/GI/Base/GObject.hsc
+++ b/base/Data/GI/Base/GObject.hsc
@@ -35,7 +35,7 @@ module Data.GI.Base.GObject
     , gobjectInstallProperty
     , gobjectInstallCIntProperty
     , gobjectInstallCStringProperty
-    , gobjectInstallCBoolProperty
+    , gobjectInstallGBooleanProperty
     ) where
 
 import Data.Maybe (catMaybes)
@@ -70,8 +70,8 @@ import Data.GI.Base.CallStack (HasCallStack, prettyCallStack)
 import Data.GI.Base.GParamSpec (PropertyInfo(..),
                                 gParamSpecValue,
                                 CIntPropertyInfo(..), CStringPropertyInfo(..),
-                                CBoolPropertyInfo(..),
-                                gParamSpecCInt, gParamSpecCString, gParamSpecCBool,
+                                GBooleanPropertyInfo(..),
+                                gParamSpecCInt, gParamSpecCString, gParamSpecGBoolean,
                                 getGParamSpecGetterSetter,
                                 PropGetSetter(..))
 import Data.GI.Base.GQuark (GQuark(..), gQuarkFromString)
@@ -414,10 +414,10 @@ gobjectInstallCStringProperty klass propInfo = do
   withManagedPtr pspec $ \pspecPtr ->
     g_object_class_install_property klass 1 pspecPtr
 
--- | Add a `Foreign.C.CBool`-valued property to the given object class.
-gobjectInstallCBoolProperty :: DerivedGObject o =>
-                            GObjectClass -> CBoolPropertyInfo o -> IO ()
-gobjectInstallCBoolProperty klass propInfo = do
-  pspec <- gParamSpecCBool propInfo
+-- | Add a `${type gboolean}`-valued property to the given object class.
+gobjectInstallGBooleanProperty :: DerivedGObject o =>
+                               GObjectClass -> GBooleanPropertyInfo o -> IO ()
+gobjectInstallGBooleanProperty klass propInfo = do
+  pspec <- gParamSpecGBoolean propInfo
   withManagedPtr pspec $ \pspecPtr ->
     g_object_class_install_property klass 1 pspecPtr

--- a/base/Data/GI/Base/GParamSpec.hsc
+++ b/base/Data/GI/Base/GParamSpec.hsc
@@ -20,8 +20,8 @@ module Data.GI.Base.GParamSpec
   , gParamSpecCString
   , CIntPropertyInfo(..)
   , gParamSpecCInt
-  , CBoolPropertyInfo(..)
-  , gParamSpecCBool
+  , GBooleanPropertyInfo(..)
+  , gParamSpecGBoolean
   , GParamFlag(..)
 
   -- * Get\/Set
@@ -29,13 +29,13 @@ module Data.GI.Base.GParamSpec
   , getGParamSpecGetterSetter
   ) where
 
-import Foreign.C (CInt(..), CString, CBool(..))
+import Foreign.C (CInt(..), CString)
 import Foreign.Ptr (Ptr, FunPtr, castPtr, nullPtr)
 import Foreign.StablePtr (newStablePtr, deRefStablePtr,
                           castStablePtrToPtr, castPtrToStablePtr)
-import Foreign.Marshal.Utils (fromBool)
 import Control.Monad (void)
 import Data.Coerce (coerce)
+import Data.Int
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 
@@ -323,7 +323,7 @@ gParamSpecCString (CStringPropertyInfo {..}) =
         gParamSpecSetQData pspecPtr quark (wrapGetSet getter setter gvalueSet_)
         wrapGParamSpecPtr pspecPtr
 
--- | Information on a property of type `CBool` to be registered. A
+-- | Information on a property of type `type gboolean` to be registered. A
 -- property name consists of segments consisting of ASCII letters and
 -- digits, separated by either the \'-\' or \'_\' character. The first
 -- character of a property name must be a letter. Names which violate
@@ -339,7 +339,7 @@ gParamSpecCString (CStringPropertyInfo {..}) =
 -- as a label for the property in a property editor, and the @blurb@,
 -- which should be a somewhat longer description, suitable for e.g. a
 -- tooltip. The @nick@ and @blurb@ should ideally be localized.
-data CBoolPropertyInfo o = CBoolPropertyInfo
+data GBooleanPropertyInfo o = GBooleanPropertyInfo
   { name   :: Text
   , nick   :: Text
   , blurb  :: Text
@@ -350,16 +350,16 @@ data CBoolPropertyInfo o = CBoolPropertyInfo
   }
 
 foreign import ccall g_param_spec_boolean ::
-  CString -> CString -> CString -> CBool -> CInt -> IO (Ptr GParamSpec)
+  CString -> CString -> CString -> #{type gboolean} -> CInt -> IO (Ptr GParamSpec)
 
 -- | Create a `GParamSpec` for a bool param.
-gParamSpecCBool :: GObject o => CBoolPropertyInfo o -> IO GParamSpec
-gParamSpecCBool (CBoolPropertyInfo {..}) =
+gParamSpecGBoolean :: GObject o => GBooleanPropertyInfo o -> IO GParamSpec
+gParamSpecGBoolean (GBooleanPropertyInfo {..}) =
   withTextCString name $ \cname ->
     withTextCString nick $ \cnick ->
       withTextCString blurb $ \cblurb -> do
         pspecPtr <- g_param_spec_boolean cname cnick cblurb
-                        (CBool (fromBool defaultValue))
+                        ((fromIntegral . fromEnum) defaultValue)
                         (maybe defaultFlags gflagsToWord flags)
         quark <- pspecQuark
         gParamSpecSetQData pspecPtr quark (wrapGetSet getter setter gvalueSet_)

--- a/base/Data/GI/Base/GParamSpec.hsc
+++ b/base/Data/GI/Base/GParamSpec.hsc
@@ -20,6 +20,8 @@ module Data.GI.Base.GParamSpec
   , gParamSpecCString
   , CIntPropertyInfo(..)
   , gParamSpecCInt
+  , CBoolPropertyInfo(..)
+  , gParamSpecCBool
   , GParamFlag(..)
 
   -- * Get\/Set
@@ -27,10 +29,11 @@ module Data.GI.Base.GParamSpec
   , getGParamSpecGetterSetter
   ) where
 
-import Foreign.C (CInt(..), CString)
+import Foreign.C (CInt(..), CString, CBool(..))
 import Foreign.Ptr (Ptr, FunPtr, castPtr, nullPtr)
 import Foreign.StablePtr (newStablePtr, deRefStablePtr,
                           castStablePtrToPtr, castPtrToStablePtr)
+import Foreign.Marshal.Utils (fromBool)
 import Control.Monad (void)
 import Data.Coerce (coerce)
 import Data.Maybe (fromMaybe)
@@ -316,6 +319,48 @@ gParamSpecCString (CStringPropertyInfo {..}) =
             withTextCString value $ \cdefault ->
               g_param_spec_string cname cnick cblurb cdefault
                     (maybe defaultFlags gflagsToWord flags)
+        quark <- pspecQuark
+        gParamSpecSetQData pspecPtr quark (wrapGetSet getter setter gvalueSet_)
+        wrapGParamSpecPtr pspecPtr
+
+-- | Information on a property of type `CBool` to be registered. A
+-- property name consists of segments consisting of ASCII letters and
+-- digits, separated by either the \'-\' or \'_\' character. The first
+-- character of a property name must be a letter. Names which violate
+-- these rules lead to undefined behaviour.
+--
+-- When creating and looking up a property, either separator can be
+-- used, but they cannot be mixed. Using \'-\' is considerably more
+-- efficient and in fact required when using property names as detail
+-- strings for signals.
+--
+-- Beyond the name, properties have two more descriptive strings
+-- associated with them, the @nick@, which should be suitable for use
+-- as a label for the property in a property editor, and the @blurb@,
+-- which should be a somewhat longer description, suitable for e.g. a
+-- tooltip. The @nick@ and @blurb@ should ideally be localized.
+data CBoolPropertyInfo o = CBoolPropertyInfo
+  { name   :: Text
+  , nick   :: Text
+  , blurb  :: Text
+  , defaultValue :: Bool
+  , flags  :: Maybe [GParamFlag]
+  , setter :: o -> Bool -> IO ()
+  , getter :: o -> IO (Bool)
+  }
+
+foreign import ccall g_param_spec_boolean ::
+  CString -> CString -> CString -> CBool -> CInt -> IO (Ptr GParamSpec)
+
+-- | Create a `GParamSpec` for a bool param.
+gParamSpecCBool :: GObject o => CBoolPropertyInfo o -> IO GParamSpec
+gParamSpecCBool (CBoolPropertyInfo {..}) =
+  withTextCString name $ \cname ->
+    withTextCString nick $ \cnick ->
+      withTextCString blurb $ \cblurb -> do
+        pspecPtr <- g_param_spec_boolean cname cnick cblurb
+                        (CBool (fromBool defaultValue))
+                        (maybe defaultFlags gflagsToWord flags)
         quark <- pspecQuark
         gParamSpecSetQData pspecPtr quark (wrapGetSet getter setter gvalueSet_)
         wrapGParamSpecPtr pspecPtr


### PR DESCRIPTION
In order to avoid "unable to set property 'xx' of type 'HaskellGIStablePtr' from value of type 'gboolean'" error Native boolean GParamSpec is needed. This patch implements just that.

I have implemented simple demo to showcase usage of the ListView. (https://github.com/psiska/haskell-gobject-deriving/blob/main/gobject-deriving/app/ListEntry.hs#L144)
During initialization I have encountered the "unable to set property" during construction. I have come to conclusion native boolean GParamSpec is needed.
