### PR TITLE
Add `gtk-layers` example as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,6 @@
 	path = examples/hlabyrinth
 	url = https://github.com/cohomology/hlabyrinth
 	branch = use-haskell-gi
+[submodule "examples/gtk-layers"]
+	path = examples/gtk-layers
+	url = https://github.com/sheaf/gtk-layers


### PR DESCRIPTION
This adds the `gtk-layers` repository as a submodule of the examples folder.

I'd be happy to update the wiki as well if you think it can be helpful.