### PR TITLE
gi-gtk-hs: Bump version to 0.3.18

### DIFF
--- a/gi-gtk-hs/gi-gtk-hs.cabal
+++ b/gi-gtk-hs/gi-gtk-hs.cabal
@@ -1,5 +1,5 @@
 name:                gi-gtk-hs
-version:             0.3.17
+version:             0.3.18
 synopsis:            A wrapper for gi-gtk, adding a few more idiomatic API parts on top
 description:         A wrapper for gi-gtk, adding a few more idiomatic API parts on top
 homepage:            https://github.com/haskell-gi/haskell-gi


### PR DESCRIPTION
This updates the `gi-gtk-hs` version from 0.3.17 to 0.3.18 ~and adds a ChangeLog entry~.

After this PR is merged, the new package version could be uploaded to Hackage, which would resolve #478.

Thanks.
